### PR TITLE
Remove `use_frameworks`

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -7,8 +7,6 @@ platform :ios, '12.0'
 require 'json'
 podfile_properties = JSON.parse(File.read('./Podfile.properties.json')) rescue {}
 
-use_frameworks!
-
 target 'example' do
   pod 'GoogleMaps', '6.0.0'
   pod 'Google-Maps-iOS-Utils', '~> 4.1.0'


### PR DESCRIPTION
`use_frameworks` seems not to be needed. So I've removed that call and built the app - everything seems to work ;) 

We should avoid using frameworks as long as possible. This option will add another step that users have to apply during the installation process. Also, it won't work great with the expo ecosystem. In theory, we added support for frameworks some time ago, but I don't trust that change 😅  