### PR TITLE
Add default styling for Apple Maps GeoJSONs

### DIFF
--- a/expo-maps/ios/ExpoMaps/AppleMaps/AppleMapsGeoJsons.swift
+++ b/expo-maps/ios/ExpoMaps/AppleMaps/AppleMapsGeoJsons.swift
@@ -21,23 +21,65 @@ class AppleMapsGeoJsons: GeoJsons {
           let geometry = object.geometry.first
           if let polygon = geometry as? MKPolygon {
             let expoPolygon = ExpoMKPolygon(points: polygon.points(), count: polygon.pointCount)
+            applyPolygonDefaultStyle(polygon: expoPolygon, defaultStyle: geoJsonObject.defaultStyle)
             mapView.addOverlay(expoPolygon)
             overlays.append(expoPolygon)
           }
           if let polyline = geometry as? MKPolyline {
             let expoPolyline = ExpoMKPolyline(points: polyline.points(), count: polyline.pointCount)
+            applyPolylineDefaultStyle(polyline: expoPolyline, defaultStyle: geoJsonObject.defaultStyle)
             mapView.addOverlay(expoPolyline)
             overlays.append(expoPolyline)
           }
           if let marker = geometry as? MKPointAnnotation {
-            mapView.addAnnotation(marker)
-            annotations.append(marker)
+            let expoMarker = ExpoMKColorAnnotation(coordinate: CLLocationCoordinate2D(latitude: marker.coordinate.latitude, longitude: marker.coordinate.longitude))
+            applyMarkerDefaultStyle(marker: expoMarker, defaultStyle: geoJsonObject.defaultStyle)
+            mapView.addAnnotation(expoMarker)
+            annotations.append(expoMarker)
           }
         }
       }
     } else {
       // Fallback on earlier versions
     }
+  }
+  
+  private func applyPolygonDefaultStyle(polygon: ExpoMKPolygon, defaultStyle: GeoJsonObjectDefaultStyle?) {
+    if (defaultStyle?.polygon?.strokeColor != nil) {
+      polygon.strokeColor = defaultStyle!.polygon!.strokeColor!
+    }
+    if (defaultStyle?.polygon?.fillColor != nil) {
+      polygon.fillColor = defaultStyle!.polygon!.fillColor!
+    }
+    if (defaultStyle?.polygon?.strokeWidth != nil) {
+      polygon.strokeWidth = defaultStyle!.polygon!.strokeWidth!
+    }
+    if (defaultStyle?.polygon?.strokeJointType != nil) {
+      polygon.jointType = jointToCGLineJoin(defaultStyle!.polygon!.strokeJointType!)
+    }
+    if (defaultStyle?.polygon?.strokeJointType != nil) {
+      polygon.strokePattern = strokePatternToLineDashPatternPolygon(pattern: defaultStyle!.polygon!.strokePattern!) 
+    }
+  }
+  
+  private func applyPolylineDefaultStyle(polyline: ExpoMKPolyline, defaultStyle: GeoJsonObjectDefaultStyle?) {
+    if (defaultStyle?.polyline?.color != nil) {
+      polyline.color = defaultStyle!.polyline!.color!
+    }
+    if (defaultStyle?.polyline?.width != nil) {
+      polyline.width = Float(defaultStyle!.polyline!.width!)
+    }
+    if (defaultStyle?.polyline?.pattern != nil) {
+      polyline.pattern = strokePatternToLineDashPatternPolyline(pattern: defaultStyle!.polygon!.strokePattern!, dotLength: 0)
+    }
+  }
+  
+  private func applyMarkerDefaultStyle(marker: ExpoMKColorAnnotation, defaultStyle: GeoJsonObjectDefaultStyle?) {
+    var hue: CGFloat = 0
+    defaultStyle?.marker?.color?.getHue(&hue, saturation: nil, brightness: nil, alpha: nil)
+    marker.title = defaultStyle?.marker?.title
+    marker.subtitle = defaultStyle?.marker?.snippet
+    marker.color = hue
   }
   
   func deleteGeoJsons() {

--- a/expo-maps/ios/ExpoMaps/AppleMaps/AppleMapsPolygons.swift
+++ b/expo-maps/ios/ExpoMaps/AppleMaps/AppleMapsPolygons.swift
@@ -49,45 +49,12 @@ class AppleMapsPolygons: Polygons {
     if polygonObject.strokeColor != nil { polygon.strokeColor = polygonObject.strokeColor! }
     if polygonObject.strokeWidth != nil { polygon.strokeWidth = polygonObject.strokeWidth! }
     if polygonObject.strokePattern != nil {
-      polygon.strokePattern = strokePatternToLineDashPattern(
+      polygon.strokePattern = strokePatternToLineDashPatternPolygon(
         pattern: polygonObject.strokePattern, width: polygon.strokeWidth)
       if polygonObject.strokeWidth == nil {polygon.strokeWidth = 1.0}
     }
     polygon.jointType = jointToCGLineJoin(polygonObject.jointType)
     
     return polygon
-  }
-
-  private func jointToCGLineJoin(_ jointType: Joint?) -> CGLineJoin {
-    switch jointType {
-    case .miter:
-      return .miter
-    case .round:
-      return .round
-    case .bevel:
-      return .bevel
-    default:
-      return .round
-    }
-  }
-
-  private func strokePatternToLineDashPattern(pattern: [PatternItem]?, width: Float = 2) -> [NSNumber]? {
-    if pattern == nil { return nil }
-    var LDP: [NSNumber] = []
-    for patternItem in pattern! {
-      switch (patternItem.type, LDP.count % 2) {
-      case (.stroke, 0):
-        LDP.append(NSNumber(value: patternItem.length))
-      case (.stroke, _):
-        LDP[LDP.count - 1] = NSNumber(value: LDP.last as! Float + patternItem.length)
-      case (.gap, 1):
-        LDP.append(NSNumber(value: patternItem.length))
-      case _:
-        if !LDP.isEmpty {
-          LDP[LDP.count - 1] = NSNumber(value: LDP.last as! Float + patternItem.length)
-        }
-      }
-    }
-    return LDP
   }
 }

--- a/expo-maps/ios/ExpoMaps/AppleMaps/AppleMapsPolylines.swift
+++ b/expo-maps/ios/ExpoMaps/AppleMaps/AppleMapsPolylines.swift
@@ -48,53 +48,12 @@ class AppleMapsPolylines: Polylines {
     if polylineObject.color != nil { polyline.color = polylineObject.color! }
     if polylineObject.width != nil { polyline.width = polylineObject.width! }
     let dotLength = polylineObject.capType == .butt ? polyline.width : 0
-    polyline.pattern = strokePatternToLineDashPattern(
+    polyline.pattern = strokePatternToLineDashPatternPolyline(
       pattern: polylineObject.pattern, dotLength: dotLength)
     polyline.jointType = jointToCGLineJoin(polylineObject.jointType)
     polyline.capType = capToCGLineCap(polylineObject.capType)
     
     return polyline
-  }
-
-  private func strokePatternToLineDashPattern(pattern: [PatternItem]?, dotLength: Float) -> [NSNumber]? {
-    if pattern == nil { return nil }
-    var LDP: [NSNumber] = []
-    for patternItem in pattern! {
-      // Parity of so-far array is the easiest indicator, whether last inserted element is a stroke or a gap
-      switch (patternItem.type, patternItem.length, LDP.count % 2) {
-      case (.stroke, 0, 0):  // Dot after gap
-        LDP.append(NSNumber(value: dotLength))
-        LDP.append(1)
-      case (.stroke, _, 0):  // Dash after gap
-        LDP.append(NSNumber(value: patternItem.length))
-      case (.stroke, _, 0):  // Dot after dash
-        LDP.append(1)
-        LDP.append(NSNumber(value: dotLength))
-        LDP.append(1)
-      case (.stroke, _, _):  // Dash after dash (merge)
-        LDP[LDP.count - 1] = NSNumber(value: LDP.last as! Float + patternItem.length)
-      case (.gap, _, 1):  // Gap after any stroke
-        LDP.append(NSNumber(value: patternItem.length))
-      case _:  // Gap after gap (merge)
-        if !LDP.isEmpty {
-          LDP[LDP.count - 1] = NSNumber(value: LDP.last as! Float + patternItem.length)
-        }
-      }
-    }
-    return LDP
-  }
-
-  private func jointToCGLineJoin(_ jointType: Joint?) -> CGLineJoin {
-    switch jointType {
-    case .miter:
-      return .miter
-    case .round:
-      return .round
-    case .bevel:
-      return .bevel
-    default:
-      return .round
-    }
   }
 
   private func capToCGLineCap(_ capType: Cap?) -> CGLineCap {

--- a/expo-maps/ios/ExpoMaps/PropsData.swift
+++ b/expo-maps/ios/ExpoMaps/PropsData.swift
@@ -110,7 +110,7 @@ struct GeoJsonObjectDefaultStylePolygon: Record {
   @Field var fillColor: UIColor?
   @Field var strokeColor: UIColor?
   @Field var strokeWidth: Float?
-  @Field var strokeJointType: String?
+  @Field var strokeJointType: Joint?
   @Field var strokePattern: [PatternItem]?
 }
 


### PR DESCRIPTION
# Why 

Enable default GeoJSON styling functionality on Apple Maps.

# How 

I reused existing styling mechanism for polygons, polylines and markers on Apple Maps and used `geoJsonObject.defaultStyle` prop data as a default style source.

# Test Plan

### iOS 

- run `pod install`
- build 
- go through the `example` app
![IMG_7664](https://user-images.githubusercontent.com/55145344/169169032-72b23ccf-63d9-473c-ac66-bdda309384b4.PNG)

