### PR TITLE
Replace `ExpoModulesCore` deprecated methods

### DIFF
--- a/expo-maps/android/src/main/java/expo/modules/maps/ExpoGoogleMapsModule.kt
+++ b/expo-maps/android/src/main/java/expo/modules/maps/ExpoGoogleMapsModule.kt
@@ -8,92 +8,93 @@ import expo.modules.maps.googleMaps.GoogleMapsView
 class ExpoGoogleMapsModule : Module() {
 
   override fun definition() = ModuleDefinition {
-    name("ExpoGoogleMaps")
+    Name("ExpoGoogleMaps")
 
-    viewManager {
-      view {
+    ViewManager {
+      View {
         GoogleMapsView(it).also { googleMapsView ->
           appContext.legacyModule<UIManager>()
             ?.registerLifecycleEventListener(googleMapsView.lifecycleEventListener)
         }
       }
 
-      prop("enableRotateGestures") { view: GoogleMapsView, enable: Boolean ->
+      Prop("enableRotateGestures") { view: GoogleMapsView, enable: Boolean ->
         view.setEnabledRotateGestures(enable)
       }
 
-      prop("enableScrollGestures") { view: GoogleMapsView, enable: Boolean ->
+      Prop("enableScrollGestures") { view: GoogleMapsView, enable: Boolean ->
         view.setEnabledScrollGestures(enable)
       }
 
-      prop("enableTiltRotateGestures") { view: GoogleMapsView, enable: Boolean ->
+      Prop("enableTiltRotateGestures") { view: GoogleMapsView, enable: Boolean ->
         view.setEnabledTiltGestures(enable)
       }
 
-      prop("enableZoomGestures") { view: GoogleMapsView, enable: Boolean ->
+      Prop("enableZoomGestures") { view: GoogleMapsView, enable: Boolean ->
         view.setEnabledZoomGestures(enable)
       }
 
-      prop("mapType") { view: GoogleMapsView, mapType: MapType ->
+      Prop("mapType") { view: GoogleMapsView, mapType: MapType ->
         view.setMapType(mapType)
       }
 
-      prop("showZoomControls") { view: GoogleMapsView, enable: Boolean ->
+      Prop("showZoomControls") { view: GoogleMapsView, enable: Boolean ->
         view.setShowZoomControl(enable)
       }
 
-      prop("showCompass") { view: GoogleMapsView, enable: Boolean ->
+      Prop("showCompass") { view: GoogleMapsView, enable: Boolean ->
         view.setShowCompass(enable)
       }
 
-      prop("showMapToolbar") { view: GoogleMapsView, enable: Boolean ->
+      Prop("showMapToolbar") { view: GoogleMapsView, enable: Boolean ->
         view.setShowMapToolbar(enable)
       }
 
-      prop("showMyLocationButton") { view: GoogleMapsView, enable: Boolean ->
+      Prop("showMyLocationButton") { view: GoogleMapsView, enable: Boolean ->
         view.setShowMyLocationButton(enable)
       }
-      prop("showLevelPicker") { view: GoogleMapsView, enable: Boolean ->
+
+      Prop("showLevelPicker") { view: GoogleMapsView, enable: Boolean ->
         view.setShowLevelPicker(enable)
       }
 
-      prop("googleMapsJsonStyleString") { view: GoogleMapsView, jsonStyleString: String ->
+      Prop("googleMapsJsonStyleString") { view: GoogleMapsView, jsonStyleString: String ->
         view.setMapStyle(jsonStyleString)
       }
 
-      prop("markers") { view: GoogleMapsView, markerObjects: Array<MarkerObject> ->
+      Prop("markers") { view: GoogleMapsView, markerObjects: Array<MarkerObject> ->
         view.setMarkers(markerObjects)
       }
 
-      prop("polygons") { view: GoogleMapsView, polygonObjects: Array<PolygonObject> ->
+      Prop("polygons") { view: GoogleMapsView, polygonObjects: Array<PolygonObject> ->
         view.setPolygons(polygonObjects)
       }
 
-      prop("polylines") { view: GoogleMapsView, polylineObjects: Array<PolylineObject> ->
+      Prop("polylines") { view: GoogleMapsView, polylineObjects: Array<PolylineObject> ->
         view.setPolylines(polylineObjects)
       }
 
-      prop("initialCameraPosition") { view: GoogleMapsView, initialCameraPosition: CameraPosition ->
+      Prop("initialCameraPosition") { view: GoogleMapsView, initialCameraPosition: CameraPosition ->
         view.setInitialCameraPosition(initialCameraPosition)
       }
 
-      prop("circles") { view: GoogleMapsView, circleObjects: Array<CircleObject> ->
+      Prop("circles") { view: GoogleMapsView, circleObjects: Array<CircleObject> ->
         view.setCircles(circleObjects)
       }
 
-      prop("clusters") { view: GoogleMapsView, clusterObjects: Array<ClusterObject> ->
+      Prop("clusters") { view: GoogleMapsView, clusterObjects: Array<ClusterObject> ->
         view.setClusters(clusterObjects)
       }
 
-      prop("enableTraffic") { view: GoogleMapsView, enable: Boolean ->
+      Prop("enableTraffic") { view: GoogleMapsView, enable: Boolean ->
         view.setEnabledTraffic(enable)
       }
 
-      prop("kmls") { view: GoogleMapsView, kmlObjects: Array<KMLObject> ->
+      Prop("kmls") { view: GoogleMapsView, kmlObjects: Array<KMLObject> ->
         view.setKMLs(kmlObjects)
       }
 
-      prop("geojsons") { view: GoogleMapsView, geoJsonObjects: Array<GeoJsonObject> ->
+      Prop("geojsons") { view: GoogleMapsView, geoJsonObjects: Array<GeoJsonObject> ->
         view.setGeoJsons(geoJsonObjects)
       }
     }

--- a/expo-maps/ios/ExpoMaps/ExpoAppleMapsModule.swift
+++ b/expo-maps/ios/ExpoMaps/ExpoAppleMapsModule.swift
@@ -3,78 +3,78 @@ import ExpoModulesCore
 public class ExpoAppleMapsModule: Module {
 
   public func definition() -> ModuleDefinition {
-    name("ExpoAppleMaps")
+    Name("ExpoAppleMaps")
 
-    viewManager {
-      view {
+    ViewManager {
+      View {
         AppleMapsView()
       }
 
-      prop("showCompass") { (view: AppleMapsView, enable: Bool) in
+      Prop("showCompass") { (view: AppleMapsView, enable: Bool) in
         view.setShowCompass(enable: enable)
       }
 
-      prop("showMyLocationButton") { (view: AppleMapsView, enable: Bool) in
+      Prop("showMyLocationButton") { (view: AppleMapsView, enable: Bool) in
         view.setShowMyLocationButton(enable: enable)
       }
 
-      prop("showLevelPicker") { (view: AppleMapsView, enable: Bool) in
+      Prop("showLevelPicker") { (view: AppleMapsView, enable: Bool) in
         view.setShowLevelPicker(enable: enable)
       }
 
-      prop("enableRotateGestures") { (view: AppleMapsView, enable: Bool) in
+      Prop("enableRotateGestures") { (view: AppleMapsView, enable: Bool) in
         view.setEnabledRotateGestures(enabled: enable)
       }
 
-      prop("enableScrollGestures") { (view: AppleMapsView, enable: Bool) in
+      Prop("enableScrollGestures") { (view: AppleMapsView, enable: Bool) in
         view.setEnabledScrollGestures(enabled: enable)
       }
 
-      prop("enableTiltGestures") { (view: AppleMapsView, enable: Bool) in
+      Prop("enableTiltGestures") { (view: AppleMapsView, enable: Bool) in
         view.setEnabledTiltGestures(enabled: enable)
       }
 
-      prop("enableZoomGestures") { (view: AppleMapsView, enable: Bool) in
+      Prop("enableZoomGestures") { (view: AppleMapsView, enable: Bool) in
         view.setEnabledZoomGestures(enabled: enable)
       }
 
-      prop("mapType") { (view: AppleMapsView, mapType: MapType) in
+      Prop("mapType") { (view: AppleMapsView, mapType: MapType) in
         view.setMapType(mapType: mapType)
       }
 
-      prop("markers") { (view: AppleMapsView, markerObjects: [MarkerObject]) in
+      Prop("markers") { (view: AppleMapsView, markerObjects: [MarkerObject]) in
         view.setMarkers(markerObjects: markerObjects)
       }
       
-      prop("clusters") { (view: AppleMapsView, clusterObjects: [ClusterObject]) in
+      Prop("clusters") { (view: AppleMapsView, clusterObjects: [ClusterObject]) in
         view.setClusters(clusterObjects: clusterObjects)
       }
 
-      prop("polygons") { (view: AppleMapsView, polygonObjects: [PolygonObject]) in
+      Prop("polygons") { (view: AppleMapsView, polygonObjects: [PolygonObject]) in
         view.setPolygons(polygonObjects: polygonObjects)
       }
 
-      prop("polylines") { (view: AppleMapsView, polylineObjects: [PolylineObject]) in
+      Prop("polylines") { (view: AppleMapsView, polylineObjects: [PolylineObject]) in
         view.setPolylines(polylineObjects: polylineObjects)
       }
 
-      prop("circles") { (view: AppleMapsView, circleObjects: [CircleObject]) in
+      Prop("circles") { (view: AppleMapsView, circleObjects: [CircleObject]) in
         view.setCircles(circleObjects: circleObjects)
       }
       
-      prop("initialCameraPosition") { (view: AppleMapsView, cameraPosition: CameraPosition) in
+      Prop("initialCameraPosition") { (view: AppleMapsView, cameraPosition: CameraPosition) in
         view.setInitialCameraPosition(initialCameraPosition: cameraPosition)
       }
       
-      prop("enableTraffic") { (view: AppleMapsView, enable: Bool) in
+      Prop("enableTraffic") { (view: AppleMapsView, enable: Bool) in
         view.setEnabledTraffic(enableTraffic: enable)
       }
       
-      prop("kmls") { (view: AppleMapsView, kmlObjects: [KMLObject]) in
+      Prop("kmls") { (view: AppleMapsView, kmlObjects: [KMLObject]) in
         view.setKMLs(kmlObjects: kmlObjects)
       }
       
-      prop("geojsons") { (view: AppleMapsView, geoJsonObjects: [GeoJsonObject]) in
+      Prop("geojsons") { (view: AppleMapsView, geoJsonObjects: [GeoJsonObject]) in
         view.setGeoJsons(geoJsonObjects: geoJsonObjects)
       }
     }

--- a/expo-maps/ios/ExpoMaps/ExpoGoogleMapsModule.swift
+++ b/expo-maps/ios/ExpoMaps/ExpoGoogleMapsModule.swift
@@ -3,82 +3,82 @@ import ExpoModulesCore
 public class ExpoGoogleMapsModule: Module {
 
   public func definition() -> ModuleDefinition {
-    name("ExpoGoogleMaps")
+    Name("ExpoGoogleMaps")
 
-    viewManager {
-      view {
+    ViewManager {
+      View {
         GoogleMapsView()
       }
 
-      prop("showCompass") { (view: GoogleMapsView, enable: Bool) in
+      Prop("showCompass") { (view: GoogleMapsView, enable: Bool) in
         view.setShowCompass(enable: enable)
       }
 
-      prop("showMyLocationButton") { (view: GoogleMapsView, enable: Bool) in
+      Prop("showMyLocationButton") { (view: GoogleMapsView, enable: Bool) in
         view.setShowMyLocationButton(enable: enable)
       }
 
-      prop("showLevelPicker") { (view: GoogleMapsView, enable: Bool) in
+      Prop("showLevelPicker") { (view: GoogleMapsView, enable: Bool) in
         view.setShowLevelPicker(enable: enable)
       }
 
-      prop("enableRotateGestures") { (view: GoogleMapsView, enable: Bool) in
+      Prop("enableRotateGestures") { (view: GoogleMapsView, enable: Bool) in
         view.setEnabledRotateGestures(enabled: enable)
       }
 
-      prop("enableScrollGestures") { (view: GoogleMapsView, enable: Bool) in
+      Prop("enableScrollGestures") { (view: GoogleMapsView, enable: Bool) in
         view.setEnabledScrollGestures(enabled: enable)
       }
 
-      prop("enableTiltGestures") { (view: GoogleMapsView, enable: Bool) in
+      Prop("enableTiltGestures") { (view: GoogleMapsView, enable: Bool) in
         view.setEnabledTiltGestures(enabled: enable)
       }
 
-      prop("enableZoomGestures") { (view: GoogleMapsView, enable: Bool) in
+      Prop("enableZoomGestures") { (view: GoogleMapsView, enable: Bool) in
         view.setEnabledZoomGestures(enabled: enable)
       }
 
-      prop("mapType") { (view: GoogleMapsView, mapType: MapType) in
+      Prop("mapType") { (view: GoogleMapsView, mapType: MapType) in
         view.setMapType(mapType: mapType)
       }
 
-      prop("googleMapsJsonStyleString") { (view: GoogleMapsView, jsonStyleString: String) in
+      Prop("googleMapsJsonStyleString") { (view: GoogleMapsView, jsonStyleString: String) in
         view.setMapStyle(jsonStyleString: jsonStyleString)
       }
 
-      prop("markers") { (view: GoogleMapsView, markerObjects: [MarkerObject]) in
+      Prop("markers") { (view: GoogleMapsView, markerObjects: [MarkerObject]) in
         view.setMarkers(markerObjects: markerObjects)
       }
       
-      prop("clusters") { (view: GoogleMapsView, clusterObjects: [ClusterObject]) in
+      Prop("clusters") { (view: GoogleMapsView, clusterObjects: [ClusterObject]) in
         view.setClusters(clusterObjects: clusterObjects)
       }
 
-      prop("polygons") { (view: GoogleMapsView, polygonObjects: [PolygonObject]) in
+      Prop("polygons") { (view: GoogleMapsView, polygonObjects: [PolygonObject]) in
         view.setPolygons(polygonObjects: polygonObjects)
       }
 
-      prop("polylines") { (view: GoogleMapsView, polylineObjects: [PolylineObject]) in
+      Prop("polylines") { (view: GoogleMapsView, polylineObjects: [PolylineObject]) in
         view.setPolylines(polylineObjects: polylineObjects)
       }
 
-      prop("initialCameraPosition") { (view: GoogleMapsView, cameraPosition: CameraPosition) in
+      Prop("initialCameraPosition") { (view: GoogleMapsView, cameraPosition: CameraPosition) in
         view.setInitialCameraPosition(initialCameraPosition: cameraPosition)
       }
 
-      prop("circles") { (view: GoogleMapsView, circleObjects: [CircleObject]) in
+      Prop("circles") { (view: GoogleMapsView, circleObjects: [CircleObject]) in
         view.setCircles(circleObjects: circleObjects)
       }
       
-      prop("enableTraffic") { (view: GoogleMapsView, enable: Bool) in
+      Prop("enableTraffic") { (view: GoogleMapsView, enable: Bool) in
         view.setEnabledTraffic(enableTraffic: enable)
       }
       
-      prop("kmls") { (view: GoogleMapsView, kmlObjects: [KMLObject]) in
+      Prop("kmls") { (view: GoogleMapsView, kmlObjects: [KMLObject]) in
         view.setKMLs(kmlObjects: kmlObjects)
       }
       
-      prop("geojsons") { (view: GoogleMapsView, geoJsonObjects: [GeoJsonObject]) in
+      Prop("geojsons") { (view: GoogleMapsView, geoJsonObjects: [GeoJsonObject]) in
         view.setGeoJsons(geoJsonObjects: geoJsonObjects)
       }
     }


### PR DESCRIPTION
# Why 

Closes #74.
`ExpoModulesCore` has deprecated previously used naming convention and switched to the new one in which most of its native methods names start from upper case letter. All the methods of the `ExpoModulesCore` package which use old convention will be depreciated soon, so I updated our library to use their new substitutes.

# How 

Make methods names start from upper case letter.

# Test Plan

### iOS 

- build 
- go through the `example` app

### Android 

- build
- go through the `example` app

