### PR TITLE
Reverse `GoogleMaps` pod update (downgrade to 6.0.0)

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -20,8 +20,8 @@ PODS:
     - ExpoModulesCore
   - ExpoMaps (1.0.0):
     - ExpoModulesCore
-    - Google-Maps-iOS-Utils
-    - GoogleMaps
+    - Google-Maps-iOS-Utils (~> 4.1.0)
+    - GoogleMaps (= 6.0.0)
   - ExpoModulesCore (0.9.2):
     - React-Core
     - ReactCommon/turbomodule/core
@@ -540,7 +540,7 @@ SPEC CHECKSUMS:
   EXLocation: 013b5d07cca26c2d15d998766322e70b7a228b57
   Expo: 64d52669fa3b9342919b5b44b2b4f15f19b0cf76
   ExpoKeepAwake: c0c494b442ecd8122974c13b93ccfb57bd408e88
-  ExpoMaps: fc3bd829f44a65a6d949f6f687942abc8ee2bf7e
+  ExpoMaps: 6c077aef162e5a5e6e4cd67fc2a0726db88f3b53
   ExpoModulesCore: e4278a668e8c13c0269ed8b8a4200989deea2973
   EXSplashScreen: 34f460788db8d682883871708dddbfac72095bb7
   FBLazyVector: a7a655862f6b09625d11c772296b01cd5164b648

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -57,10 +57,10 @@ PODS:
     - GoogleMaps
   - Google-Maps-iOS-Utils/QuadTree (4.1.0):
     - GoogleMaps
-  - GoogleMaps (6.2.0):
-    - GoogleMaps/Maps (= 6.2.0)
-  - GoogleMaps/Base (6.2.0)
-  - GoogleMaps/Maps (6.2.0):
+  - GoogleMaps (6.0.0):
+    - GoogleMaps/Maps (= 6.0.0)
+  - GoogleMaps/Base (6.0.0)
+  - GoogleMaps/Maps (6.0.0):
     - GoogleMaps/Base
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -548,7 +548,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
   Google-Maps-iOS-Utils: 3343332b18dfd5be8f1f44edd7d481ace3da4d9a
-  GoogleMaps: c1b9de14cecc940b2d334dd4e6dfa116bff4a40e
+  GoogleMaps: 750f237920fa44dd32de0c0d2004d35cb2c688f3
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
@@ -583,4 +583,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 0c550cbcfe1ccd7e5da7babdac489912a558e1d1
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/expo-maps/ios/ExpoMaps.podspec
+++ b/expo-maps/ios/ExpoMaps.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'GoogleMaps'
-  s.dependency 'Google-Maps-iOS-Utils'
+  s.dependency 'GoogleMaps', '6.0.0'
+  s.dependency 'Google-Maps-iOS-Utils', '~> 4.1.0'
 end


### PR DESCRIPTION
# Why 

After updates in [#72](https://github.com/software-mansion-labs/expo-maps/pull/72) it seems like camera position is malfunctioning on Google Maps for iOS. I wasn't able to fix this bug using newer version `6.2.0` so far, but downgrade to previous version `6.0.0` helps as a temporary fix for this issue, so we have stable version of the demo app on `main` branch. We should create a separate PR in which we update this pod to newer version and resolve this issue.

Before (6.2.0):

https://user-images.githubusercontent.com/55145344/170604598-3f139ba5-ce56-42c5-a188-46aedae2394d.MOV


After (6.0.0)

https://user-images.githubusercontent.com/55145344/170604766-8411d45e-e3a5-42b9-8486-a91169956548.MOV


# How 

Downgrade `GoogleMaps` pod to version `6.0.0`.

# Test Plan

### iOS 

- build 
- go through the `example` app