### PR TITLE
Fix: demo app controls example screen

### DIFF
--- a/example/screens/ControlsExample.tsx
+++ b/example/screens/ControlsExample.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, View } from 'react-native';
 import * as Maps from 'expo-maps';
 import SwitchContainer from '../components/SwitchContainer';
 import ProviderContext from '../context/ProviderContext';
+import { Platform } from 'expo-modules-core';
 
 export default function ControlsExample() {
   const provider = useContext(ProviderContext);
@@ -25,9 +26,10 @@ export default function ControlsExample() {
         showMyLocationButton={showMyLocationButton}
         showLevelPicker={showLevelPicker}
         showMapToolbar={showMapToolbar}
+        enableRotateGestures={true}
       />
       <View style={{ padding: 20 }}>
-        {provider == 'google' && (
+        {Platform.OS == 'android' && (
           <SwitchContainer
             title="Show zoom controls"
             value={showZoomControls}
@@ -49,7 +51,7 @@ export default function ControlsExample() {
           value={showLevelPicker}
           onValueChange={() => setShowLevelPicker(!showLevelPicker)}
         />
-        {provider == 'google' && (
+        {Platform.OS == 'android' && (
           <SwitchContainer
             title="Show map toolbar"
             value={showMapToolbar}


### PR DESCRIPTION
- enabling rotate gesture for controls example screen in order to properly display compass button
- removing zoom controls and tool bar from Google Maps on iOS since this functionality is not supported there